### PR TITLE
fix(push): ensure bucketname is correctly set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,13 @@ function getLabels(l) {
   return labels;
 }
 
-async function pushMetadata(data, bucket) {
+async function pushMetadata(bucket, data) {
+  if (!bucket) {
+    throw new Error('metadataBucket input for artifact metadata not set');
+  }
+  if (!bucket.startsWith('gs://')) {
+    throw new Error('metadataBucket input must start with gs://');
+  }
   const tmpFile = 'tmp-slipstream-metadata.json';
   fs.writeFile(tmpFile, JSON.stringify(data, null, '  '), (err) => {
     if (err) {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -31,23 +31,33 @@ test('pushFilesToBucket calls gsutil correctly', async() => {
   );
 });
 
-test('pushMetadata calls gsutil correctly', async() => {
-  const bucket = 'gs://random-bucket'
+describe('pushMetadata', () => {
   const data = {
     service: 'a-service',
     build: {
       id: '1234'
     }
-  }
-  await pushMetadata(data, bucket);
+  };
+  test('throws if bucket string not set', async () => {
+    const bucket = undefined;
+    await expect(pushMetadata(bucket, data)).rejects.toThrow(/metadataBucket/);
+  });
+  test('throws if bucket string does not include gs:// prefix', async () => {
+    const bucket = 'bucketname';
+    await expect(pushMetadata(bucket, data)).rejects.toThrow(/gs:\/\//);
+  });
+  test('calls gsutil correctly', async() => {
+    const bucket = 'gs://random-bucket'
+    await pushMetadata(bucket, data);
 
-  const expectedBucketRegex = new RegExp(/^gs:\/\/random-bucket\/a-service\/github-build\.1234\..{3}\.json$/)
+    const expectedBucketRegex = new RegExp(/^gs:\/\/random-bucket\/a-service\/github-build\.1234\..{3}\.json$/)
 
-  expect(exec.exec.mock.calls.length).toBe(1);
-  expect(exec.exec.mock.calls[0][0]).toBe('gsutil');
-  expect(exec.exec.mock.calls[0][1][0]).toBe('cp');
-  expect(exec.exec.mock.calls[0][1][1]).toBe('./tmp-slipstream-metadata.json');
-  expect(exec.exec.mock.calls[0][1][2]).toMatch(expectedBucketRegex);
+    expect(exec.exec.mock.calls.length).toBe(1);
+    expect(exec.exec.mock.calls[0][0]).toBe('gsutil');
+    expect(exec.exec.mock.calls[0][1][0]).toBe('cp');
+    expect(exec.exec.mock.calls[0][1][1]).toBe('./tmp-slipstream-metadata.json');
+    expect(exec.exec.mock.calls[0][1][2]).toMatch(expectedBucketRegex);
+  });
 });
 
 describe('getLabels returns correct JSON', () => {

--- a/push-files/dist/index.js
+++ b/push-files/dist/index.js
@@ -1283,7 +1283,7 @@ async function run() {
       filesStageUrl: core.getInput('stageVersionCheckURL'),
       filesProdUrl: core.getInput('productionVersionCheckURL'),
     })
-    await pushMetadata(data);
+    await pushMetadata(metadataBucket, data);
     core.endGroup();
 
     core.setOutput('artifactID', hash);
@@ -4476,7 +4476,13 @@ function getLabels(l) {
   return labels;
 }
 
-async function pushMetadata(data, bucket) {
+async function pushMetadata(bucket, data) {
+  if (!bucket) {
+    throw new Error('metadataBucket input for artifact metadata not set');
+  }
+  if (!bucket.startsWith('gs://')) {
+    throw new Error('metadataBucket input must start with gs://');
+  }
   const tmpFile = 'tmp-slipstream-metadata.json';
   fs.writeFile(tmpFile, JSON.stringify(data, null, '  '), (err) => {
     if (err) {

--- a/push-files/index.js
+++ b/push-files/index.js
@@ -25,7 +25,7 @@ async function run() {
       filesStageUrl: core.getInput('stageVersionCheckURL'),
       filesProdUrl: core.getInput('productionVersionCheckURL'),
     })
-    await pushMetadata(data);
+    await pushMetadata(metadataBucket, data);
     core.endGroup();
 
     core.setOutput('artifactID', hash);

--- a/push-image/index.js
+++ b/push-image/index.js
@@ -6,7 +6,8 @@ const util = require('./util');
 
 async function run() {
   const service = core.getInput('service');
-  const registry = core.getInput('dockerRegistry')
+  const registry = core.getInput('dockerRegistry');
+  const metadataBucket = core.getInput('metadataBucket');
   const tag = process.env.GITHUB_RUN_ID;
   const repoTag = `${registry}/${service}:${tag}`;
 
@@ -36,7 +37,7 @@ async function run() {
       repoTag,
       labels: core.getInput('labels'),
     })
-    await pushMetadata(data);
+    await pushMetadata(metadataBucket, data);
     core.endGroup();
 
     core.setOutput('imageDigest', util.getImageDigest(data.dockerInspect));


### PR DESCRIPTION
This also adds some checks for the expected bucket pattern because
if it's incorrect gsutil can do unexpected things like copying
files around locally rather than into a bucket.