### PR TITLE
feat(push-files): Compress files and avoid overwrites

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ async function pushMetadata(bucket, data) {
   // generated filenames, so re-runs don't cause files to be overwritten.
   const uid = new ShortUniqueId({ length: 3 });
   const filename = `github-build.${data.build.id}.${uid()}.json`;
-  await exec.exec('gsutil', ['cp', `./${tmpFile}`, `${bucket}/${data.service}/${filename}`], {});
+  await exec.exec('gsutil', ['cp', '-z', 'json', `./${tmpFile}`, `${bucket}/${data.service}/${filename}`], {});
   await fs.unlink(tmpFile, (err) => {
     if (err) {
       throw Error(`failed to delete temp JSON metadata file: ${err.message}`);
@@ -87,10 +87,13 @@ async function pushMetadata(bucket, data) {
 }
 
 async function pushFilesToBucket(files, bucketAddress) {
+  const args = '-rnz'; // recursive, no-overwrite, zip
+  const zipExtensions = 'css,html,js,json,svg';
+
   await exec.exec('gsutil', [
     '-m',
     '-h', 'Cache-Control:public, max-age=31536000',
-    'cp', '-r', '.',
+    'cp', args, zipExtensions, '.',
     bucketAddress,
   ], {
     cwd: files,

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -32,7 +32,7 @@ test('pushFilesToBucket calls gsutil correctly', async () => {
       '-m',
       '-h',
       'Cache-Control:public, max-age=31536000',
-      'cp', '-r', '.',
+      'cp', '-rnz', 'css,html,js,json,svg', '.',
       'gs://bucket/path/',
     ],
     {
@@ -59,13 +59,19 @@ describe('pushMetadata', () => {
     const bucket = 'gs://random-bucket';
     await pushMetadata(bucket, data);
 
-    const expectedBucketRegex = new RegExp(/^gs:\/\/random-bucket\/a-service\/github-build\.1234\..{3}\.json$/);
-
     expect(exec.exec.mock.calls.length).toBe(1);
-    expect(exec.exec.mock.calls[0][0]).toBe('gsutil');
-    expect(exec.exec.mock.calls[0][1][0]).toBe('cp');
-    expect(exec.exec.mock.calls[0][1][1]).toBe('./tmp-slipstream-metadata.json');
-    expect(exec.exec.mock.calls[0][1][2]).toMatch(expectedBucketRegex);
+    expect(exec.exec).toHaveBeenCalledWith(
+      'gsutil',
+      expect.arrayContaining([
+        'cp',
+        '-z',
+        'json',
+        expect.stringContaining(
+          'gs://random-bucket/a-service/github-build.1234.',
+        ),
+      ]),
+      {},
+    );
   });
 });
 


### PR DESCRIPTION
This PR adds two arguments to the `gsutil cp` command. Since the `gsutil help` command does a really good job at explaining the arguments, I will just copy-paste the docs here.


## `-n`

> When specified, existing files or objects at the destination will not be overwritten. Any items that are skipped by this option will be reported as being skipped. This option will perform an additional GET request to check if an item exists before attempting to upload the data. This will save retransmitting data, but the additional HTTP requests may make small object transfers slower and more expensive.


## `-z`

> Applies gzip content-encoding to any file upload whose extension matches the -z extension list. This is useful when uploading files with compressible content (such as .js, .css, or .html files) because it saves network bandwidth and space in Google Cloud Storage, which in turn reduces storage costs.
>
> When you specify the -z option, the data from your files is compressed before it is uploaded, but your actual files are left uncompressed on the local disk. The uploaded objects retain the Content-Type and name of the original files but are given a Content-Encoding header with the value "gzip" to indicate that the object data stored are compressed on the Google Cloud Storage servers.
>
> For example, the following command:
>
>gsutil cp -z html -a public-read \
>    cattypes.html tabby.jpeg gs://mycats
>
>will do all of the following:
>
>- Upload the files cattypes.html and tabby.jpeg to the bucket
>gs://mycats (cp command)
>- Set the Content-Type of cattypes.html to text/html and
>tabby.jpeg to image/jpeg (based on file extensions)
>- Compress the data in the file cattypes.html (-z option)
>- Set the Content-Encoding for cattypes.html to gzip
>(-z option)
>- Set the ACL for both files to public-read (-a option)
>- If a user tries to view cattypes.html in a browser, the browser will know to uncompress the data based on the Content-Encoding header and to render it as HTML based on the Content-Type header.
>
>Note that if you download an object with Content-Encoding:gzip gsutil will decompress the content before writing the local file.