### PR TITLE
fix: ensure double quotes in commit message does not break the action

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,19 +12,20 @@ const githubRunNumber = process.env.GITHUB_RUN_NUMBER;
 const githubSHA = process.env.GITHUB_SHA;
 
 async function getCommitData() {
+  const prettyArg = `--pretty=format:${'%H %an %s'.split(' ').join('%n')}`;
   const log = await git()
     .raw([
       'log',
       '-1',
-      '--pretty=format:{%n  "commit": "%H",%n  "author": "%an",%n  "author_email": "%ae",%n  "date": "%ad",%n  "message": "%s"%n}',
-    ], (err, res) => res);
-  const commit = JSON.parse(log);
+      prettyArg,
+    ]);
+  const [sha, author, message] = log.split('\n');
 
   return {
-    author: commit.author,
-    message: commit.message,
-    sha: commit.commit,
-    url: `https://github.com/${githubRepo}/commit/${commit.commit}`,
+    author,
+    message,
+    sha,
+    url: `https://github.com/${process.env.GITHUB_REPOSITORY}/commit/${sha}`,
   };
 }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -3,9 +3,19 @@ jest.mock('@actions/exec', () => ({
   exec: jest.fn(),
 }));
 
+jest.mock('simple-git/promise', () => {
+  const mGit = {
+    raw: jest.fn(() => new Promise((resolve) => {
+      resolve('09415108c57b1bcdeeae4a2992de00580c074f27\nbw-hubot\nEscape "double quotes"');
+    })),
+  };
+  return jest.fn(() => mGit);
+});
+
 const {
   pushFilesToBucket,
   pushMetadata,
+  getCommitData,
   getLabels,
 } = require('./index');
 
@@ -77,5 +87,20 @@ describe('getLabels throws', () => {
   });
   test('with non delimited pairs', () => {
     expect(() => getLabels('k1=v1k2=v2')).toThrow(Error);
+  });
+});
+
+describe('getCommitData', () => {
+  test('with non delimited pairs', async () => {
+    process.env.GITHUB_REPOSITORY = 'foo/bar';
+
+    const json = await getCommitData();
+    expect(json).toStrictEqual({
+      author: 'bw-hubot',
+      message: 'Escape "double quotes"',
+      sha: '09415108c57b1bcdeeae4a2992de00580c074f27',
+      url:
+        'https://github.com/foo/bar/commit/09415108c57b1bcdeeae4a2992de00580c074f27',
+    });
   });
 });


### PR DESCRIPTION
One of our workflows broke, because the commit message contain double quotes. The way how this action constructs the git log data as a JSON string is causing this issue. I changed the implementing to return each information separated by a new line. That way no JSON.parse is required.

![image](https://user-images.githubusercontent.com/1393946/88223947-9663a800-cc68-11ea-90c5-df6db0160a43.png)

https://github.com/BrandwatchLtd/consumer-research/runs/893912107#step:15:159

