### PR TITLE
fix: Remove empty outputs prop that is causing runs to fail

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -10,7 +10,6 @@ inputs:
   id:
     description: ID of artifact to deploy, e.g. image digest, files sha, module digest.
     required: true
-outputs:
 
 runs:
   using: node12


### PR DESCRIPTION
I experienced some issues with the action:

```
##[debug]action.yml for action: '/home/runner/work/_actions/BrandwatchLtd/slipstream-actions/main/push-files/action.yml'.
##[debug]Action 'BrandwatchLtd/slipstream-actions@main' already downloaded at '/home/runner/work/_actions/BrandwatchLtd/slipstream-actions/main'.
##[debug]action.yml for action: '/home/runner/work/_actions/BrandwatchLtd/slipstream-actions/main/deploy/action.yml'.
##[error]BrandwatchLtd/slipstream-actions/main/deploy/action.yml (Line: 13, Col: 9): Unexpected value ''
##[error]BrandwatchLtd/slipstream-actions/main/deploy/action.yml (Line: 13, Col: 9): Unexpected value ''
##[error]System.ArgumentException: Unexpected type 'NullToken' encountered while reading 'outputs'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
##[error]Fail to load BrandwatchLtd/slipstream-actions/main/deploy/action.yml
##[debug]System.ArgumentException: Fail to load BrandwatchLtd/slipstream-actions/main/deploy/action.yml
##[debug]   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
##[debug]   at GitHub.Runner.Worker.ActionManager.PrepareRepositoryActionAsync(IExecutionContext executionContext, ActionStep repositoryAction)
##[debug]   at GitHub.Runner.Worker.ActionManager.PrepareActionsAsync(IExecutionContext executionContext, IEnumerable`1 steps)
##[debug]   at GitHub.Runner.Worker.JobExtension.InitializeJob(IExecutionContext jobContext, AgentJobRequestMessage message)
```

@stefanbuck made me aware of a recent release of Github Actions that coincides with the date when this issue started appearing: https://github.blog/changelog/2020-08-03-github-actions-new-runner-release-v2-272-0/

My assuming is that the `outputs` property must not be empty. I'm going to try and run a PR against this branch and if that's successful it should prove this is okay to remove.