### PR TITLE
Trim generated hash to get rid of new line

### DIFF
--- a/push-files/dist/index.js
+++ b/push-files/dist/index.js
@@ -4138,7 +4138,7 @@ async function getHashOfFiles(filesDir) {
     options,
   );
 
-  return tard;
+  return tard.trim();
 }
 
 async function writeSlipstreamCheckFile(id, filesDir) {

--- a/push-files/push.js
+++ b/push-files/push.js
@@ -51,7 +51,7 @@ async function getHashOfFiles(filesDir) {
     options,
   );
 
-  return tard;
+  return tard.trim();
 }
 
 async function writeSlipstreamCheckFile(id, filesDir) {

--- a/push-files/push.test.js
+++ b/push-files/push.test.js
@@ -2,7 +2,9 @@ process.env.GITHUB_RUN_NUMBER = '2345';
 
 jest.mock('@actions/exec', () => ({
   exec: jest.fn((cmd, args, options) => {
-    options.listeners.stdout('638b46454a5u95520e07');
+    // exec returns a new line so we need to include this here as well
+    // to ensure our trim() works as expected
+    options.listeners.stdout('638b46454a5u95520e07\n');
   }),
 }));
 


### PR DESCRIPTION
While testing the recent changes I've noticed the following output

```
Pushing files to GCR: gs://bw-stage-analytics0-consumer-research-cdn/consumer-research/explore/fab10c70a56185321e7a%0A/
```

The `%0A` at the end is coming from the exec output so we need to trim the hash before returning it. 