### PR TITLE
feat(push-files): Do not upload files including metadata when content is already uploaded

### DIFF
--- a/.github/workflows/lib-test.yaml
+++ b/.github/workflows/lib-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2.1.1
+    - uses: actions/setup-node@main
       with:
         node-version: 12.x
     - run: npm install # In the root for shared dev deps

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,10 +100,18 @@ async function pushFilesToBucket(files, bucketAddress) {
   });
 }
 
+async function directoryExists(url) {
+  return exec.exec('gsutil', [
+    'ls',
+    url,
+  ]).then(() => true).catch(() => false);
+}
+
 module.exports = {
   getCommitData,
   getBuildData,
   getLabels,
+  directoryExists,
   pushMetadata,
   pushFilesToBucket,
 };

--- a/push-files/dist/index.js
+++ b/push-files/dist/index.js
@@ -3838,10 +3838,18 @@ async function pushFilesToBucket(files, bucketAddress) {
   });
 }
 
+async function directoryExists(url) {
+  return exec.exec('gsutil', [
+    'ls',
+    url,
+  ]).then(() => true).catch(() => false);
+}
+
 module.exports = {
   getCommitData,
   getBuildData,
   getLabels,
+  directoryExists,
   pushMetadata,
   pushFilesToBucket,
 };
@@ -6244,6 +6252,7 @@ const core = __webpack_require__(793);
 const githubEvent = require(process.env.GITHUB_EVENT_PATH);
 const {
   pushMetadata,
+  directoryExists,
   pushFilesToBucket,
 } = __webpack_require__(354);
 const push = __webpack_require__(459);
@@ -6256,6 +6265,13 @@ async function run() {
     const metadataBucket = core.getInput('metadataBucket');
     const hash = await push.getHashOfFiles(filesDir);
     const bucketAddress = `${bucket}/${service}/${hash}/`;
+
+    const existsAlready = await directoryExists(bucketAddress);
+
+    if (existsAlready) {
+      core.info(`Skip: ${bucketAddress} already exists`);
+      return;
+    }
 
     core.startGroup(`Pushing files to GCR: ${bucketAddress}`);
     await push.writeSlipstreamCheckFile(hash, filesDir);

--- a/push-files/dist/index.js
+++ b/push-files/dist/index.js
@@ -6270,6 +6270,8 @@ async function run() {
 
     if (existsAlready) {
       core.info(`Skip: ${bucketAddress} already exists`);
+      core.setOutput('artifactID', hash);
+      core.setOutput('skipped', 'true');
       return;
     }
 
@@ -6292,6 +6294,7 @@ async function run() {
     core.endGroup();
 
     core.setOutput('artifactID', hash);
+    core.setOutput('skipped', 'false');
     core.info('success');
     core.info(`Run 'slipstream list files -s ${service}' to view service images`);
   } catch (err) {

--- a/push-files/index.js
+++ b/push-files/index.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const githubEvent = require(process.env.GITHUB_EVENT_PATH);
 const {
   pushMetadata,
+  directoryExists,
   pushFilesToBucket,
 } = require('../lib');
 const push = require('./push');
@@ -14,6 +15,13 @@ async function run() {
     const metadataBucket = core.getInput('metadataBucket');
     const hash = await push.getHashOfFiles(filesDir);
     const bucketAddress = `${bucket}/${service}/${hash}/`;
+
+    const existsAlready = await directoryExists(bucketAddress);
+
+    if (existsAlready) {
+      core.info(`Skip: ${bucketAddress} already exists`);
+      return;
+    }
 
     core.startGroup(`Pushing files to GCR: ${bucketAddress}`);
     await push.writeSlipstreamCheckFile(hash, filesDir);

--- a/push-files/index.js
+++ b/push-files/index.js
@@ -20,6 +20,8 @@ async function run() {
 
     if (existsAlready) {
       core.info(`Skip: ${bucketAddress} already exists`);
+      core.setOutput('artifactID', hash);
+      core.setOutput('skipped', 'true');
       return;
     }
 
@@ -42,6 +44,7 @@ async function run() {
     core.endGroup();
 
     core.setOutput('artifactID', hash);
+    core.setOutput('skipped', 'false');
     core.info('success');
     core.info(`Run 'slipstream list files -s ${service}' to view service images`);
   } catch (err) {

--- a/push-image/dist/index.js
+++ b/push-image/dist/index.js
@@ -4141,10 +4141,18 @@ async function pushFilesToBucket(files, bucketAddress) {
   });
 }
 
+async function directoryExists(url) {
+  return exec.exec('gsutil', [
+    'ls',
+    url,
+  ]).then(() => true).catch(() => false);
+}
+
 module.exports = {
   getCommitData,
   getBuildData,
   getLabels,
+  directoryExists,
   pushMetadata,
   pushFilesToBucket,
 };


### PR DESCRIPTION
In the https://github.com/BrandwatchLtd/consumer-research main branch pipeline we perform a build of all apps to ensure no changes are slipping through. This also means we run `BrandwatchLtd/slipstream-actions/push-files` on every app. We thought slipstream will not accept an identical upload but this turn to be out not the truth. Although the GCS upload is skipped (due to the use of `-n` no-overwrite) the slipstream metadata file still gets uploaded which then creates a new deployment item in slipstream. 

![image](https://user-images.githubusercontent.com/1393946/101763499-294d9380-3adf-11eb-863a-737d4928a197.png)


This change uses `gsutil ls` to check if files already exists in GCS, if so it will skip the metadata upload as well