### PR TITLE
Noticket fix nested directories in push files

### DIFF
--- a/push-files/dist/index.js
+++ b/push-files/dist/index.js
@@ -6811,7 +6811,7 @@ async function getHashOfFiles(filesDir) {
     let output = '';
 
     walker.on('file', async (root, fileStats, next) => {
-      const filename = path.join(filesDir, fileStats.name);
+      const filename = path.join(root, fileStats.name);
       core.debug(`Read content of ${filename}`);
 
       const fileContent = await fs.readFile(filename);

--- a/push-files/fixtures/baz/quux.js
+++ b/push-files/fixtures/baz/quux.js
@@ -1,0 +1,1 @@
+String('hello nested world');

--- a/push-files/push.js
+++ b/push-files/push.js
@@ -35,7 +35,7 @@ async function getHashOfFiles(filesDir) {
     let output = '';
 
     walker.on('file', async (root, fileStats, next) => {
-      const filename = path.join(filesDir, fileStats.name);
+      const filename = path.join(root, fileStats.name);
       core.debug(`Read content of ${filename}`);
 
       const fileContent = await fs.readFile(filename);

--- a/push-files/push.test.js
+++ b/push-files/push.test.js
@@ -35,7 +35,7 @@ test('builds correct metadata', async () => {
 
 test('generates a content hash', async () => {
   const hash = await getHashOfFiles('./fixtures');
-  expect(hash).toBe('775de5a308edde41f9ad');
+  expect(hash).toBe('b5c5f8dc2fefaf577fb9');
 });
 
 test('throws an error if content hash genertion fails', async () => {


### PR DESCRIPTION
As discussed earlier with @stefanbuck.

This got updated in February, however it turns out that we haven't used this action for any projects with nested directories in the build since then.

This update simply ensures the correct path is used when walking through nested directories during the getHashOfFiles() method.

Please note the first commit simply updates the build with no other changes. Neither me nor Stefan could figure out why running `npm run dev` changed the `dist/index.js` file so much - advice welcome!