### PR TITLE
NOTICKET Add additional options argument to push-image

### DIFF
--- a/push-image/index.js
+++ b/push-image/index.js
@@ -31,6 +31,7 @@ async function run() {
       path: core.getInput('path'),
       push: core.getInput('push'),
       buildArgs: core.getInput('buildArgs'),
+      additionalOptions: core.getInput('additionalOptions'),
       repo,
     });
 

--- a/push-image/push.js
+++ b/push-image/push.js
@@ -19,6 +19,10 @@ async function buildImage(input) {
     }
   }
 
+  if (input.additionalOptions) {
+    args.push(input.additionalOptions);
+  }
+
   args.push(input.path);
 
   await dockerCommand(args.join(' '));

--- a/push-image/push.test.js
+++ b/push-image/push.test.js
@@ -46,6 +46,17 @@ describe('passes corrects args to docker build', () => {
     expect(docker.dockerCommand)
       .toHaveBeenCalledWith('build --tag thing1 --file dockf1 --build-arg k1=v1 --build-arg k2=v2 path1');
   });
+  test('with additional options', async () => {
+    await buildImage({
+      repo: 'thing1',
+      dockerfile: 'dockf1',
+      path: 'path1',
+      buildArgs: 'k1=v1,k2=v2',
+      additionalOptions: '--secret id=npmrc,src=.npmrc --ssh default=foo',
+    });
+    expect(docker.dockerCommand)
+      .toHaveBeenCalledWith('build --tag thing1 --file dockf1 --build-arg k1=v1 --build-arg k2=v2 --secret id=npmrc,src=.npmrc --ssh default=foo path1');
+  });
 });
 
 test('calls tagImage correctly', async () => {


### PR DESCRIPTION
The current options are good, but not comprehensive. What about
--secret? or --ssh? We could add these explicitly, but there'll still be
[others](https://docs.docker.com/engine/reference/commandline/build/)
which aren't supported. This change allows users to pass in additional
options verbatim.