### PR TITLE
feat: temporary remove slipstream install script

### DIFF
--- a/install-cli/action.yml
+++ b/install-cli/action.yml
@@ -4,7 +4,8 @@ inputs:
   url:
     description: URL of the slipstream binary to download
     required: false
-    default: https://raw.githubusercontent.com/BrandwatchLtd/slipstream-cli-release/master/install.sh
+    default: https://github.com/BrandwatchLtd/slipstream-cli-release/releases/download/v0.7.0%2Bslipstream/slipstream-cli-release_0.7.0+slipstream_linux_amd64.tar.gz
+
 runs:
   using: node12
   main: dist/index.js


### PR DESCRIPTION
We are removing the slipstream installation script as few actions failed to install the slipstream-cli. 
The script might be set again after we have investigated.

Broken github actions 👇 
https://github.com/BrandwatchLtd/consumer-research/runs/4457350977?check_suite_focus=true