### PR TITLE
feat: add compressed attribute support

### DIFF
--- a/push-webapp/action.yml
+++ b/push-webapp/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Weather or not the index file is a template
     required: false
     default: 'false'
+  compressed:
+    description: The index file is compressed by default
+    required: false
+    default: 'false'
   labels:
     description: Comma separated key=value labels.
     required: false

--- a/push-webapp/index.js
+++ b/push-webapp/index.js
@@ -16,6 +16,7 @@ async function run() {
     const service = core.getInput('service');
     const indexFile = core.getInput('indexFile');
     const templated = core.getInput('templated') === 'true';
+    const compressed = core.getInput('compressed') === 'true';
     const labels = core.getInput('labels');
     const webappDir = core.getInput('staticRoot');
     const bucket = core.getInput('artifactBucket');
@@ -56,7 +57,7 @@ async function run() {
     }
 
     core.startGroup(`Pushing files to Bucket: ${bucketAddress}`);
-    await writeMetadataFile(version, webappDir, indexFile, templated);
+    await writeMetadataFile(version, webappDir, indexFile, templated, compressed);
     await pushFilesToBucket(webappDir, bucketAddress);
     core.endGroup();
 

--- a/push-webapp/push.js
+++ b/push-webapp/push.js
@@ -24,12 +24,13 @@ async function buildSlipstreamMetadata(input) {
   return data;
 }
 
-async function writeMetadataFile(id, dir, index, templated) {
+async function writeMetadataFile(id, dir, index, templated, compressed) {
   const file = path.resolve(dir, 'metadata.json');
   const data = {
     version: id,
     index,
     templated,
+    compressed,
   };
 
   await fs.access(path.resolve(dir, index), fs.F_OK);


### PR DESCRIPTION
It is possible to use compressed metadata option:
https://github.com/BrandwatchLtd/WebappService/#metadata

I would like to disable compression to support `sub_filter` nginx module.