### PR TITLE
feat(push-image): use execFilerSync instead of docker-cli-js to execute docker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5518,11 +5518,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@actions/exec": "^1.1.1",
-        "docker-cli-js": "^2.8.0"
+        "@actions/exec": "^1.1.1"
       }
     },
     "push-module": {
+      "name": "slipstream-action-push-module",
       "version": "1.0.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
@@ -9198,8 +9198,7 @@
       "version": "file:push-image",
       "requires": {
         "@actions/core": "^1.10.0",
-        "@actions/exec": "^1.1.1",
-        "docker-cli-js": "^2.8.0"
+        "@actions/exec": "^1.1.1"
       }
     },
     "slipstream-action-push-module": {

--- a/push-image/action.yml
+++ b/push-image/action.yml
@@ -40,5 +40,5 @@ outputs:
   imageDigest:
     description: The image digest of the Docker image. Can be used to request a deployment.
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/push-image/docker.js
+++ b/push-image/docker.js
@@ -1,13 +1,13 @@
+const core = require('@actions/core');
+
 const { execFileSync } = require('child_process');
 
 function docker(command, ...args) {
   const out = execFileSync('docker', [command, ...args], { env: process.env }).toString('utf-8');
 
-  /* eslint-disable no-console */
-  console.log(`::group::> docker ${command} ${args.join(' ')}`);
-  console.log(out);
-  console.log('::endgroup::');
-  /* eslint-enable no-console */
+  core.group(`::group::> docker ${command} ${args.join(' ')}`, () => {
+    core.info(out);
+  });
 
   return out;
 }
@@ -18,7 +18,7 @@ function dockerJSON(command, ...args) {
   try {
     return JSON.parse(out);
   } catch (err) {
-    console.error(`:error::Failed to parse json output for "docker ${command} ${args.join(' ')}"`);
+    core.error(`Failed to parse json output for "docker ${command} ${args.join(' ')}"`);
     throw err;
   }
 }

--- a/push-image/docker.js
+++ b/push-image/docker.js
@@ -1,0 +1,29 @@
+const { execFileSync } = require('child_process');
+
+function docker(command, ...args) {
+  const out = execFileSync('docker', [command, ...args], { env: process.env }).toString('utf-8');
+
+  /* eslint-disable no-console */
+  console.log(`::group::> docker ${command} ${args.join(' ')}`);
+  console.log(out);
+  console.log('::endgroup::');
+  /* eslint-enable no-console */
+
+  return out;
+}
+
+function dockerJSON(command, ...args) {
+  const out = docker(command, ...args);
+
+  try {
+    return JSON.parse(out);
+  } catch (err) {
+    console.error(`:error::Failed to parse json output for "docker ${command} ${args.join(' ')}"`);
+    throw err;
+  }
+}
+
+module.exports = {
+  docker,
+  dockerJSON,
+};

--- a/push-image/docker.test.js
+++ b/push-image/docker.test.js
@@ -1,0 +1,49 @@
+process.env.GITHUB_RUN_NUMBER = '2345';
+
+const { execFileSync } = require('child_process');
+const { docker, dockerJSON } = require('./docker');
+
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+}));
+
+const { env: ENV } = process;
+
+beforeEach(() => {
+  execFileSync.mockReset();
+  execFileSync.mockReturnValue(Buffer.alloc(0));
+
+  jest.spyOn(global.console, 'error').mockImplementation(() => {});
+  jest.spyOn(global.console, 'log').mockImplementation(() => {});
+
+  process.env = { FOO: 'bar' };
+});
+
+afterAll(() => {
+  process.env = ENV;
+});
+
+describe('docker())', () => {
+  it('should pass process.env to process', async () => {
+    docker('build', '.');
+
+    expect(execFileSync).toBeCalledWith('docker', ['build', '.'], { env: { FOO: 'bar' } });
+  });
+});
+
+describe('dockerJSON())', () => {
+  it('should return json object', async () => {
+    execFileSync.mockReturnValue(Buffer.from('{ "test": 1 }'));
+
+    expect(dockerJSON('docker', 'context', 'inspect')).toEqual({ test: 1 });
+  });
+
+  it('should fail if docker response is not valid json', async () => {
+    execFileSync.mockReturnValue(Buffer.from('{'));
+
+    expect(() => dockerJSON('docker', 'context', 'inspect')).toThrow();
+    expect(global.console.error).toBeCalledWith(
+      ':error::Failed to parse json output for "docker docker context inspect"',
+    );
+  });
+});

--- a/push-image/docker.test.js
+++ b/push-image/docker.test.js
@@ -1,6 +1,7 @@
 process.env.GITHUB_RUN_NUMBER = '2345';
 
 const { execFileSync } = require('child_process');
+const { EOL } = require('os');
 const { docker, dockerJSON } = require('./docker');
 
 jest.mock('child_process', () => ({
@@ -13,8 +14,7 @@ beforeEach(() => {
   execFileSync.mockReset();
   execFileSync.mockReturnValue(Buffer.alloc(0));
 
-  jest.spyOn(global.console, 'error').mockImplementation(() => {});
-  jest.spyOn(global.console, 'log').mockImplementation(() => {});
+  jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
 
   process.env = { FOO: 'bar' };
 });
@@ -42,8 +42,8 @@ describe('dockerJSON())', () => {
     execFileSync.mockReturnValue(Buffer.from('{'));
 
     expect(() => dockerJSON('docker', 'context', 'inspect')).toThrow();
-    expect(global.console.error).toBeCalledWith(
-      ':error::Failed to parse json output for "docker docker context inspect"',
+    expect(process.stdout.write).toBeCalledWith(
+      `::error::Failed to parse json output for "docker docker context inspect"${EOL}`,
     );
   });
 });

--- a/push-image/package.json
+++ b/push-image/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/exec": "^1.1.1",
-    "docker-cli-js": "^2.8.0"
+    "@actions/exec": "^1.1.1"
   }
 }

--- a/push-image/push.js
+++ b/push-image/push.js
@@ -47,7 +47,7 @@ async function buildMetadata(input) {
   data.build = metadata.getBuildData(input.event);
   data.labels = metadata.getLabels(input.labels);
   data.release = input.release;
-  data.dockerInspect = dockerJSON('inspect', input.repo).object;
+  data.dockerInspect = dockerJSON('inspect', input.repo);
 
   return data;
 }

--- a/push-image/push.test.js
+++ b/push-image/push.test.js
@@ -65,15 +65,6 @@ describe('passes corrects args to docker build', () => {
     expect(docker.docker.mock.calls[1])
       .toEqual(['build', '--tag', 'thing1', '--file', 'dockf1', '--build-arg', 'k1=v1', '--build-arg', 'k2=v2', '--secret', 'id=npmrc,src=.npmrc', '--ssh', 'default=foo', 'path1']);
   });
-  // test('passes process.env', async () => {
-  //   await buildImage({
-  //     repo: 'thing1',
-  //     dockerfile: 'dockf1',
-  //     path: 'path1',
-  //   });
-  //   expect(docker.docker.mock.calls[0][1])
-  //     .toStrictEqual({ env: { FOO: 'bar' } });
-  // });
 });
 
 test('calls tagImage correctly', async () => {
@@ -110,9 +101,7 @@ describe('getTags', () => {
 });
 
 test('builds correct metadata', async () => {
-  docker.dockerJSON.mockReturnValue({
-    object: [{ dummy: 'inspect' }],
-  });
+  docker.dockerJSON.mockReturnValue([{ dummy: 'inspect' }]);
   const data = await buildMetadata({
     event: {
       pull_request: {

--- a/push-image/push.test.js
+++ b/push-image/push.test.js
@@ -1,6 +1,6 @@
 process.env.GITHUB_RUN_NUMBER = '2345';
 
-const docker = require('docker-cli-js');
+const docker = require('./docker');
 const {
   buildImage,
   tagImage,
@@ -10,12 +10,13 @@ const {
 
 const OLD_ENV = process.env;
 
-jest.mock('docker-cli-js', () => ({
-  dockerCommand: jest.fn(),
+jest.mock('./docker', () => ({
+  docker: jest.fn(),
+  dockerJSON: jest.fn(),
 }));
 
 beforeEach(() => {
-  docker.dockerCommand.mockReset();
+  docker.docker.mockReset();
   process.env = { FOO: 'bar' };
 });
 
@@ -30,8 +31,8 @@ describe('passes corrects args to docker build', () => {
       dockerfile: 'dockf1',
       path: 'path1',
     });
-    expect(docker.dockerCommand.mock.calls[0][0])
-      .toBe('build --tag thing1 --file dockf1 path1');
+    expect(docker.docker.mock.calls[1])
+      .toEqual(['build', '--tag', 'thing1', '--file', 'dockf1', 'path1']);
   });
   test('with pull arg', async () => {
     await buildImage({
@@ -40,8 +41,8 @@ describe('passes corrects args to docker build', () => {
       path: 'path1',
       pull: true,
     });
-    expect(docker.dockerCommand.mock.calls[0][0])
-      .toBe('build --tag thing1 --file dockf1 --pull path1');
+    expect(docker.docker.mock.calls[1])
+      .toEqual(['build', '--tag', 'thing1', '--file', 'dockf1', '--pull', 'path1']);
   });
   test('with buildArgs arg', async () => {
     await buildImage({
@@ -50,8 +51,8 @@ describe('passes corrects args to docker build', () => {
       path: 'path1',
       buildArgs: 'k1=v1,k2=v2',
     });
-    expect(docker.dockerCommand.mock.calls[0][0])
-      .toBe('build --tag thing1 --file dockf1 --build-arg k1=v1 --build-arg k2=v2 path1');
+    expect(docker.docker.mock.calls[1])
+      .toEqual(['build', '--tag', 'thing1', '--file', 'dockf1', '--build-arg', 'k1=v1', '--build-arg', 'k2=v2', 'path1']);
   });
   test('with additional options', async () => {
     await buildImage({
@@ -61,24 +62,24 @@ describe('passes corrects args to docker build', () => {
       buildArgs: 'k1=v1,k2=v2',
       additionalOptions: '--secret id=npmrc,src=.npmrc --ssh default=foo',
     });
-    expect(docker.dockerCommand.mock.calls[0][0])
-      .toBe('build --tag thing1 --file dockf1 --build-arg k1=v1 --build-arg k2=v2 --secret id=npmrc,src=.npmrc --ssh default=foo path1');
+    expect(docker.docker.mock.calls[1])
+      .toEqual(['build', '--tag', 'thing1', '--file', 'dockf1', '--build-arg', 'k1=v1', '--build-arg', 'k2=v2', '--secret', 'id=npmrc,src=.npmrc', '--ssh', 'default=foo', 'path1']);
   });
-  test('passes process.env', async () => {
-    await buildImage({
-      repo: 'thing1',
-      dockerfile: 'dockf1',
-      path: 'path1',
-    });
-    expect(docker.dockerCommand.mock.calls[0][1])
-      .toStrictEqual({ env: { FOO: 'bar' } });
-  });
+  // test('passes process.env', async () => {
+  //   await buildImage({
+  //     repo: 'thing1',
+  //     dockerfile: 'dockf1',
+  //     path: 'path1',
+  //   });
+  //   expect(docker.docker.mock.calls[0][1])
+  //     .toStrictEqual({ env: { FOO: 'bar' } });
+  // });
 });
 
 test('calls tagImage correctly', async () => {
   await tagImage('imagerepo', 'newtag');
-  expect(docker.dockerCommand)
-    .toHaveBeenCalledWith('tag imagerepo imagerepo:newtag');
+  expect(docker.docker)
+    .toHaveBeenCalledWith('tag', 'imagerepo', 'imagerepo:newtag');
 });
 
 describe('getTags', () => {
@@ -109,7 +110,7 @@ describe('getTags', () => {
 });
 
 test('builds correct metadata', async () => {
-  docker.dockerCommand.mockResolvedValue({
+  docker.dockerJSON.mockReturnValue({
     object: [{ dummy: 'inspect' }],
   });
   const data = await buildMetadata({


### PR DESCRIPTION
This PR aims to solve the issues which surfaced when switching to custom github action runners:

![image](https://github.com/BrandwatchLtd/slipstream-actions/assets/423234/cc083b49-49fc-463e-a7eb-e13ac4579bea)

<br>

Unfortunately I cannot say why, but replacing the [docker-cli-js](https://www.npmjs.com/package/docker-cli-js) package by executing docker via child_process.execFileSync and updating the action to node 20 solved the issue.

See: https://github.com/brandwatch/frontend-apps/actions/runs/7409414270/job/20160283262